### PR TITLE
Config stuffs

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -65,23 +65,6 @@ var setCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set config parameters to the current working project config",
 	Run: func(cmd *cobra.Command, args []string) {
-		flagKeys := []string{
-			"setName",
-			"setTaskID",
-			"setTaskListID",
-			"setProjectID",
-			"setDate",
-			"setMessage",
-			"setHours",
-			"setMinutes",
-			"setBillable",
-		}
-
-		for _, key := range flagKeys {
-			//TODO set items to config file
-			fmt.Println("Key: {0}", key)
-		}
-
 		fmt.Println("set called")
 	},
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,23 +10,25 @@ import (
 )
 
 var (
-	initConf		*bool
+	initConf		bool
 
-	addName 		*string
-	addTaskID 		*int
-	addTaskListID 	*int
-	addProjectID 	*int
-	addDate 		*string
-	addMessage 		*string
-	addHours 		*int
-	addMinutes 		*int
-	addBillable 	*bool
+	setName 		string
+	setTaskID 		int
+	setTaskListID 	int
+	setProjectID 	int
+	setDate 		string
+	setMessage 		string
+	setHours 		int
+	setMinutes 		int
+	setBillable 	bool
 )
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "I dont know what the parent command does yet /shrug",
+	Short: "/shrug I dont know what the parent command does yet",
+	Long: `This could potentially list the current config or print some kind
+	of stats for the current project.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("config called")
 	},
@@ -41,12 +43,12 @@ var getCmd = &cobra.Command{
 	},
 }
 
-// setCmd represents the add command
-var setCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Sets a config in the current project directory",
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "/shrug I don't know what this command does yet",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("set called")
+		fmt.Println("add called")
 	},
 }
 
@@ -59,21 +61,21 @@ var initCmd = &cobra.Command{
 	},
 }
 
-// addCmd represents the add command
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "A brief description of your command",
+// setCmd represents the add command
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set config parameters to the current working project config",
 	Run: func(cmd *cobra.Command, args []string) {
 		flagKeys := []string{
-			"addName",
-			"addTaskID",
-			"addTaskListID",
-			"addProjectID",
-			"addDate",
-			"addMessage",
-			"addHours",
-			"addMinutes",
-			"addBillable",
+			"setName",
+			"setTaskID",
+			"setTaskListID",
+			"setProjectID",
+			"setDate",
+			"setMessage",
+			"setHours",
+			"setMinutes",
+			"setBillable",
 		}
 
 		for _, key := range flagKeys {
@@ -81,7 +83,7 @@ var addCmd = &cobra.Command{
 			fmt.Println("Key: {0}", key)
 		}
 
-		fmt.Println("add called")
+		fmt.Println("set called")
 	},
 }
 
@@ -94,15 +96,15 @@ func init() {
 	RootCmd.AddCommand(configCmd)
 
 	// Here you will define your flags and configuration settings.
-	configCmd.PersistentFlags().BoolVarP(initConf, "init", "i", false, "Initialize a config in the cwd (defaults to false)")
+	configCmd.PersistentFlags().BoolVarP(&initConf, "init", "i", false, "Initialize a config in the cwd (defaults to false)")
 
-	addCmd.PersistentFlags().StringVarP(addName, "name", "n", "", "Add an alias [favorite] name to the current working config")
-	addCmd.PersistentFlags().IntVarP(addTaskID, "taskId", "t", 0,"Add a Task ID for the current working config")
-	addCmd.PersistentFlags().IntVarP(addTaskListID, "taskListId", "l", 0, "Add a Task List ID for the current working config")
-	addCmd.PersistentFlags().IntVarP(addProjectID, "projectId", "p", 0, "Add a Project ID for the current working config")
-	addCmd.PersistentFlags().StringVarP(addDate, "date", "d", "", "Add a date to the current working config (mm/dd/yy)")
-	addCmd.PersistentFlags().StringVarP(addMessage, "msg", "m", "", "Add a message to the current working config")
-	addCmd.PersistentFlags().IntVarP(addHours, "hours", "h", 0, "Add default hours to the current working config")
-	addCmd.PersistentFlags().IntVar(addMinutes, "min", 0, "Add default minutes to the current working config")
-	addCmd.PersistentFlags().BoolVarP(addBillable, "billable", "b", true, "Set current working config as billable (defaults to true)")
+	setCmd.PersistentFlags().StringVarP(&setName, "name", "n", "", "Set an alias [favorite] name to the current working config")
+	setCmd.PersistentFlags().IntVarP(&setTaskID, "taskId", "t", 0,"Set a Task ID for the current working config")
+	setCmd.PersistentFlags().IntVarP(&setTaskListID, "taskListId", "l", 0, "Set a Task List ID for the current working config")
+	setCmd.PersistentFlags().IntVarP(&setProjectID, "projectId", "p", 0, "Set a Project ID for the current working config")
+	setCmd.PersistentFlags().StringVarP(&setDate, "date", "d", "", "Set a date to the current working config (mm/dd/yy)")
+	setCmd.PersistentFlags().StringVarP(&setMessage, "msg", "m", "", "Set a message to the current working config")
+	setCmd.PersistentFlags().IntVar(&setHours, "hours", 0, "Set default hours to the current working config")
+	setCmd.PersistentFlags().IntVar(&setMinutes, "min", 0, "Set default minutes to the current working config")
+	setCmd.PersistentFlags().BoolVarP(&setBillable, "billable", "b", true, "Set current working config as billable (defaults to true)")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,16 +9,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	initConf		*bool
+
+	addName 		*string
+	addTaskID 		*int
+	addTaskListID 	*int
+	addProjectID 	*int
+	addDate 		*string
+	addMessage 		*string
+	addHours 		*int
+	addMinutes 		*int
+	addBillable 	*bool
+)
+
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "I dont know what the parent command does yet /shrug",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("config called")
 	},
@@ -27,13 +35,7 @@ to quickly create a Cobra application.`,
 // addCmd represents the add command
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Returns the current project config",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("get called")
 	},
@@ -42,15 +44,18 @@ to quickly create a Cobra application.`,
 // setCmd represents the add command
 var setCmd = &cobra.Command{
 	Use:   "set",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Sets a config in the current project directory",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("set called")
+	},
+}
+
+// initCmd represents the add command
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initializes a config in the current working directory",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("init called")
 	},
 }
 
@@ -58,31 +63,28 @@ to quickly create a Cobra application.`,
 var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		flagKeys := []string{
+			"addName",
+			"addTaskID",
+			"addTaskListID",
+			"addProjectID",
+			"addDate",
+			"addMessage",
+			"addHours",
+			"addMinutes",
+			"addBillable",
+		}
+
+		for _, key := range flagKeys {
+			//TODO set items to config file
+			fmt.Println("Key: {0}", key)
+		}
+
 		fmt.Println("add called")
 	},
 }
 
-// initCmd represents the add command
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("init called")
-	},
-}
 
 func init() {
 	configCmd.AddCommand(getCmd)
@@ -92,12 +94,15 @@ func init() {
 	RootCmd.AddCommand(configCmd)
 
 	// Here you will define your flags and configuration settings.
+	configCmd.PersistentFlags().BoolVarP(initConf, "init", "i", false, "Initialize a config in the cwd (defaults to false)")
 
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// configCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// configCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	addCmd.PersistentFlags().StringVarP(addName, "name", "n", "", "Add an alias [favorite] name to the current working config")
+	addCmd.PersistentFlags().IntVarP(addTaskID, "taskId", "t", 0,"Add a Task ID for the current working config")
+	addCmd.PersistentFlags().IntVarP(addTaskListID, "taskListId", "l", 0, "Add a Task List ID for the current working config")
+	addCmd.PersistentFlags().IntVarP(addProjectID, "projectId", "p", 0, "Add a Project ID for the current working config")
+	addCmd.PersistentFlags().StringVarP(addDate, "date", "d", "", "Add a date to the current working config (mm/dd/yy)")
+	addCmd.PersistentFlags().StringVarP(addMessage, "msg", "m", "", "Add a message to the current working config")
+	addCmd.PersistentFlags().IntVarP(addHours, "hours", "h", 0, "Add default hours to the current working config")
+	addCmd.PersistentFlags().IntVar(addMinutes, "min", 0, "Add default minutes to the current working config")
+	addCmd.PersistentFlags().BoolVarP(addBillable, "billable", "b", true, "Set current working config as billable (defaults to true)")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,5 @@
 // Copyright © 2018 rtslabs
 
-
 package cmd
 
 import (
@@ -10,17 +9,17 @@ import (
 )
 
 var (
-	initConf		bool
+	initConf bool
 
-	setName 		string
-	setTaskID 		int
-	setTaskListID 	int
-	setProjectID 	int
-	setDate 		string
-	setMessage 		string
-	setHours 		int
-	setMinutes 		int
-	setBillable 	bool
+	setName       string
+	setTaskID     int
+	setTaskListID int
+	setProjectID  int
+	setDate       string
+	setMessage    string
+	setHours      int
+	setMinutes    int
+	setBillable   bool
 )
 
 // configCmd represents the config command
@@ -87,7 +86,6 @@ var setCmd = &cobra.Command{
 	},
 }
 
-
 func init() {
 	configCmd.AddCommand(getCmd)
 	configCmd.AddCommand(setCmd)
@@ -99,7 +97,7 @@ func init() {
 	configCmd.PersistentFlags().BoolVarP(&initConf, "init", "i", false, "Initialize a config in the cwd (defaults to false)")
 
 	setCmd.PersistentFlags().StringVarP(&setName, "name", "n", "", "Set an alias [favorite] name to the current working config")
-	setCmd.PersistentFlags().IntVarP(&setTaskID, "taskId", "t", 0,"Set a Task ID for the current working config")
+	setCmd.PersistentFlags().IntVarP(&setTaskID, "taskId", "t", 0, "Set a Task ID for the current working config")
 	setCmd.PersistentFlags().IntVarP(&setTaskListID, "taskListId", "l", 0, "Set a Task List ID for the current working config")
 	setCmd.PersistentFlags().IntVarP(&setProjectID, "projectId", "p", 0, "Set a Project ID for the current working config")
 	setCmd.PersistentFlags().StringVarP(&setDate, "date", "d", "", "Set a date to the current working config (mm/dd/yy)")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -33,7 +33,6 @@ var configCmd = &cobra.Command{
 	},
 }
 
-// addCmd represents the add command
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Returns the current project config",
@@ -42,16 +41,6 @@ var getCmd = &cobra.Command{
 	},
 }
 
-// addCmd represents the add command
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "/shrug I don't know what this command does yet",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("add called")
-	},
-}
-
-// initCmd represents the add command
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initializes a config in the current working directory",
@@ -60,7 +49,6 @@ var initCmd = &cobra.Command{
 	},
 }
 
-// setCmd represents the add command
 var setCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set config parameters to the current working project config",
@@ -72,12 +60,11 @@ var setCmd = &cobra.Command{
 func init() {
 	configCmd.AddCommand(getCmd)
 	configCmd.AddCommand(setCmd)
-	configCmd.AddCommand(addCmd)
 	configCmd.AddCommand(initCmd)
 	RootCmd.AddCommand(configCmd)
 
 	// Here you will define your flags and configuration settings.
-	configCmd.PersistentFlags().BoolVarP(&initConf, "init", "i", false, "Initialize a config in the cwd (defaults to false)")
+	setCmd.PersistentFlags().BoolVarP(&initConf, "init", "i", false, "Initialize a config in the cwd (defaults to false)")
 
 	setCmd.PersistentFlags().StringVarP(&setName, "name", "n", "", "Set an alias [favorite] name to the current working config")
 	setCmd.PersistentFlags().IntVarP(&setTaskID, "taskId", "t", 0, "Set a Task ID for the current working config")


### PR DESCRIPTION
* cleans up some of the help snippets in config 
* add the variables for setting config values
* add flags for set command

I noticed that the init command could potential just be a persistent flag on the config command. This would make initializing simpler and as a persistent flag it could be called with the other commands (add, get, set).

I didn't remember what is the add command for, hence the /shrug

To test:
`go run main.go --help`
`go run main.go config --help`
`go run main.go config set --help`